### PR TITLE
Migrate mixin_type_correctness_validator to ast_validtor

### DIFF
--- a/thrift/compiler/test/compiler_failure_test.py
+++ b/thrift/compiler/test/compiler_failure_test.py
@@ -395,7 +395,8 @@ class CompilerFailureTest(unittest.TestCase):
 
         self.assertEqual(ret, 1)
         self.assertEqual(
-            err, "[FAILURE:foo.thrift:2] Mixin field `i` is not a struct but `i32`.\n"
+            err,
+            "[FAILURE:foo.thrift:2] Mixin field `i` type must be a struct or union. Found `i32`.\n",
         )
 
     def test_mixin_in_union(self):
@@ -415,7 +416,7 @@ class CompilerFailureTest(unittest.TestCase):
 
         self.assertEqual(ret, 1)
         self.assertEqual(
-            err, "[FAILURE:foo.thrift:2] Union `B` can not have mixin field `a`.\n"
+            err, "[FAILURE:foo.thrift:3] Union `B` cannot contain mixin field `a`.\n"
         )
 
     def test_mixin_with_cpp_ref(self):
@@ -517,7 +518,7 @@ class CompilerFailureTest(unittest.TestCase):
         self.assertEqual(
             err,
             textwrap.dedent(
-                "[FAILURE:foo.thrift:3] Mixin field `a` can not be optional.\n"
+                "[FAILURE:foo.thrift:3] Mixin field `a` cannot be optional.\n"
             ),
         )
 

--- a/thrift/compiler/validator/validator.h
+++ b/thrift/compiler/validator/validator.h
@@ -125,16 +125,6 @@ class exception_list_is_all_exceptions_validator : virtual public validator {
   static bool validate_throws(const t_throws* throws);
 };
 
-class mixin_type_correctness_validator : virtual public validator {
- public:
-  using validator::visit;
-
-  /**
-   * Enforces that all mixin fields are struct.
-   */
-  bool visit(t_struct* s) override;
-};
-
 class field_names_uniqueness_validator : virtual public validator {
  public:
   using validator::visit;


### PR DESCRIPTION
Summary:
Start validating mixing fields in exceptions.
Make error text more consistent.
Fix line number reported for mixin field in union.

Reviewed By: vitaut

Differential Revision: D28591058

fbshipit-source-id: c2547920804d611821ab44919018418e3522f3b4