### PR TITLE
ServerInterface::clearRequestParams

### DIFF
--- a/thrift/lib/cpp2/async/AsyncProcessor.h
+++ b/thrift/lib/cpp2/async/AsyncProcessor.h
@@ -368,6 +368,8 @@ class ServerInterface : public virtual AsyncProcessorFactory,
 
   folly::EventBase* getEventBase() { return requestParams_.eventBase_; }
 
+  void clearRequestParams() { requestParams_ = RequestParams(); }
+
   /**
    * Override to return a pre-initialized RequestContext.
    * Its content will be copied in the RequestContext initialized at


### PR DESCRIPTION
Summary:
There is currently no way to correctly reset request parameters (these
are thread-local, so the logic might want to reset those in-between request
processing to avoid leaving no longer valid values around) as
`setEventBase(nullptr)` has a side-effect of changing current request context
(via embedded `RequestEventBase::set(eb)`).

Reviewed By: yfeldblum, ot, luciang

Differential Revision: D28773482

fbshipit-source-id: 38cc72417a82ebfdc2c6af96ce96f826f5b13e45