### PR TITLE
Use boost::optional for optional t_type_refs

### DIFF
--- a/thrift/compiler/ast/t_const.h
+++ b/thrift/compiler/ast/t_const.h
@@ -80,7 +80,11 @@ class t_const final : public t_named {
       const t_type* type,
       std::string name,
       std::unique_ptr<t_const_value> value)
-      : t_const(program, t_type_ref(type), std::move(name), std::move(value)) {}
+      : t_const(
+            program,
+            t_type_ref::from_req_ptr(type),
+            std::move(name),
+            std::move(value)) {}
 
   t_program* get_program() const { return program_; }
   const t_type* get_type() const { return type_.get_type(); }

--- a/thrift/compiler/ast/t_const_value.h
+++ b/thrift/compiler/ast/t_const_value.h
@@ -25,6 +25,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/optional.hpp>
+
 #include <thrift/compiler/ast/t_node.h>
 #include <thrift/compiler/ast/t_type.h>
 
@@ -187,11 +189,8 @@ class t_const_value {
 
   t_const* get_owner() const { return owner_; }
 
-  void set_ttype(std::unique_ptr<t_type_ref> type) { type_ = std::move(type); }
-
-  const t_type* get_ttype() const {
-    return type_ == nullptr ? nullptr : type_->get_type();
-  }
+  const boost::optional<t_type_ref>& ttype() const { return ttype_; }
+  void set_ttype(boost::optional<t_type_ref> type) { ttype_ = std::move(type); }
 
   void set_is_enum(bool value = true) { is_enum_ = value; }
 
@@ -222,7 +221,7 @@ class t_const_value {
 
   t_const_value_type valType_ = CV_BOOL;
   t_const* owner_ = nullptr;
-  std::unique_ptr<t_type_ref> type_;
+  boost::optional<t_type_ref> ttype_;
 
   bool is_enum_ = false;
   t_enum const* tenum_ = nullptr;
@@ -233,8 +232,9 @@ class t_const_value {
  public:
   // TODO(afuller): Delete everything below here. It is only provided for
   // backwards compatibility.
-  void set_ttype(const t_type* type) {
-    type_ = std::make_unique<t_type_ref>(type);
+  void set_ttype(const t_type* type) { ttype_ = t_type_ref::from_ptr(type); }
+  const t_type* get_ttype() const {
+    return ttype() == boost::none ? nullptr : ttype()->get_type();
   }
 };
 

--- a/thrift/compiler/ast/t_field.h
+++ b/thrift/compiler/ast/t_field.h
@@ -114,7 +114,7 @@ class t_field final : public t_named {
   };
 
   t_field(const t_type* type, std::string name, int32_t key = 0)
-      : t_field(t_type_ref(type), std::move(name), key) {}
+      : t_field(t_type_ref::from_req_ptr(type), std::move(name), key) {}
 
   void set_value(std::unique_ptr<t_const_value> value) {
     set_default_value(std::move(value));

--- a/thrift/compiler/ast/t_function.h
+++ b/thrift/compiler/ast/t_function.h
@@ -92,7 +92,7 @@ class t_function final : public t_named {
       std::unique_ptr<t_throws> exceptions = nullptr,
       t_function_qualifier qualifier = {})
       : t_function(
-            t_type_ref(return_type),
+            t_type_ref::from_req_ptr(return_type),
             std::move(name),
             std::move(paramlist),
             std::move(exceptions),

--- a/thrift/compiler/ast/t_list.h
+++ b/thrift/compiler/ast/t_list.h
@@ -44,7 +44,8 @@ class t_list final : public t_container {
   // TODO(afuller): Delete everything below here. It is only provided for
   // backwards compatibility.
  public:
-  explicit t_list(const t_type* elem_type) : t_list(t_type_ref(elem_type)) {}
+  explicit t_list(const t_type* elem_type)
+      : t_list(t_type_ref::from_req_ptr(elem_type)) {}
   const t_type* get_elem_type() const { return elem_type().get_type(); }
 };
 

--- a/thrift/compiler/ast/t_map.h
+++ b/thrift/compiler/ast/t_map.h
@@ -49,7 +49,9 @@ class t_map final : public t_container {
   // backwards compatibility.
  public:
   t_map(const t_type* key_type, const t_type* val_type)
-      : t_map(t_type_ref(key_type), t_type_ref(val_type)) {}
+      : t_map(
+            t_type_ref::from_req_ptr(key_type),
+            t_type_ref::from_req_ptr(val_type)) {}
   const t_type* get_key_type() const { return key_type().get_type(); }
   const t_type* get_val_type() const { return val_type().get_type(); }
 };

--- a/thrift/compiler/ast/t_set.h
+++ b/thrift/compiler/ast/t_set.h
@@ -43,7 +43,8 @@ class t_set final : public t_container {
   // TODO(afuller): Delete everything below here. It is only provided for
   // backwards compatibility.
  public:
-  explicit t_set(const t_type* elem_type) : t_set(t_type_ref(elem_type)) {}
+  explicit t_set(const t_type* elem_type)
+      : t_set(t_type_ref::from_req_ptr(elem_type)) {}
   const t_type* get_elem_type() const { return elem_type().get_type(); }
 };
 

--- a/thrift/compiler/ast/t_stream.h
+++ b/thrift/compiler/ast/t_stream.h
@@ -37,41 +37,46 @@ class t_stream_response : public t_templated_type {
   const t_throws* throws() const { return t_throws::or_empty(throws_.get()); }
 
   void set_first_response_type(
-      std::unique_ptr<t_type_ref> first_response_type) {
+      boost::optional<t_type_ref> first_response_type) {
     first_response_type_ = std::move(first_response_type);
   }
 
-  bool has_first_response() const { return first_response_type_ != nullptr; }
-  const t_type_ref* first_response_type() const {
-    return first_response_type_.get();
+  const boost::optional<t_type_ref>& first_response_type() const {
+    return first_response_type_;
   }
 
   std::string get_full_name() const override {
-    if (has_first_response()) {
-      return first_response_type_->deref().get_full_name() + ", stream<" +
-          elem_type_->get_full_name() + ">";
+    std::string result = "stream<" + elem_type_->get_full_name() + ">";
+    if (first_response_type_ != boost::none) {
+      result = first_response_type_->deref().get_full_name() + ", " + result;
     }
-    return "stream<" + elem_type_->get_full_name() + ">";
+    return result;
   }
 
  private:
   t_type_ref elem_type_;
   std::unique_ptr<t_throws> throws_;
-  std::unique_ptr<t_type_ref> first_response_type_;
+  boost::optional<t_type_ref> first_response_type_;
 
   // TODO(afuller): Remove everything below here. It is provided only for
   // backwards compatibility.
  public:
   explicit t_stream_response(
       const t_type* elem_type, std::unique_ptr<t_throws> throws = nullptr)
-      : t_stream_response(t_type_ref(elem_type), std::move(throws)) {}
+      : t_stream_response(
+            t_type_ref::from_req_ptr(elem_type), std::move(throws)) {}
 
   void set_first_response_type(const t_type* first_response_type) {
-    set_first_response_type(std::make_unique<t_type_ref>(first_response_type));
+    set_first_response_type(t_type_ref::from_ptr(first_response_type));
   }
   const t_type* get_elem_type() const { return elem_type().get_type(); }
   const t_type* get_first_response_type() const {
-    return has_first_response() ? first_response_type()->get_type() : nullptr;
+    return first_response_type() == boost::none
+        ? nullptr
+        : first_response_type()->get_type();
+  }
+  bool has_first_response() const {
+    return first_response_type_ != boost::none;
   }
   t_throws* get_throws_struct() const { return throws_.get(); }
   bool has_throws_struct() const { return throws_ == nullptr; }

--- a/thrift/compiler/ast/t_type.h
+++ b/thrift/compiler/ast/t_type.h
@@ -23,6 +23,8 @@
 #include <sstream>
 #include <string>
 
+#include <boost/optional.hpp>
+
 #include <thrift/compiler/ast/t_named.h>
 
 namespace apache {
@@ -208,7 +210,8 @@ class t_templated_type : public t_type {
 class t_type_ref final {
  public:
   t_type_ref() = default;
-  explicit t_type_ref(const t_type* type) : type_(type) {}
+  /* implicit */ t_type_ref(const t_type& type) : type_(&type) {}
+  /* implicit */ t_type_ref(t_type&&) = delete;
 
   // Returns the resolved type being referenced.
   //
@@ -228,6 +231,16 @@ class t_type_ref final {
   // for backwards compatibility.
  public:
   const t_type* get_type() const { return type_; }
+
+  static boost::optional<t_type_ref> from_ptr(const t_type* type) {
+    if (type == nullptr) {
+      return boost::none;
+    }
+    return t_type_ref(*type);
+  }
+  static t_type_ref from_req_ptr(const t_type* type) {
+    return from_ptr(type).value();
+  }
 };
 
 } // namespace compiler

--- a/thrift/compiler/ast/t_typedef.h
+++ b/thrift/compiler/ast/t_typedef.h
@@ -33,8 +33,6 @@ class t_typedef : public t_type {
  public:
   t_typedef(t_program* program, std::string name, t_type_ref type)
       : t_type(program, std::move(name)), type_(std::move(type)) {}
-  t_typedef(t_program* program, std::string name, const t_type* type)
-      : t_type(program, std::move(name)), type_(type) {}
 
   const t_type_ref& type() const { return type_; }
 
@@ -79,12 +77,11 @@ class t_typedef : public t_type {
  protected:
   t_type_ref type_;
 
- public:
   // TODO(afuller): Remove everything below here, as it is just provided for
   // backwards compatibility.
-
+ public:
   t_typedef(t_program* program, const t_type* type, std::string name, t_scope*)
-      : t_typedef(program, std::move(name), t_type_ref(type)) {}
+      : t_typedef(program, std::move(name), t_type_ref::from_req_ptr(type)) {}
 
   const t_type* get_type() const { return type_.get_type(); }
 

--- a/thrift/compiler/gen/cpp/type_resolver.cc
+++ b/thrift/compiler/gen/cpp/type_resolver.cc
@@ -198,7 +198,7 @@ std::string type_resolver::gen_container_type(
 
 std::string type_resolver::gen_stream_resp_type(
     const t_stream_response* node, type_resolve_fn resolve_fn) {
-  if (node->has_first_response()) {
+  if (node->first_response_type() != boost::none) {
     return detail::gen_template_type(
         "::apache::thrift::ResponseAndServerStream",
         {resolve(resolve_fn, node->get_first_response_type()),
@@ -211,7 +211,7 @@ std::string type_resolver::gen_stream_resp_type(
 
 std::string type_resolver::gen_sink_type(
     const t_sink* node, type_resolve_fn resolve_fn) {
-  if (node->has_first_response()) {
+  if (node->first_response_type() != boost::none) {
     return detail::gen_template_type(
         "::apache::thrift::ResponseAndSinkConsumer",
         {resolve(resolve_fn, node->get_first_response_type()),

--- a/thrift/compiler/generate/t_mstch_objects.h
+++ b/thrift/compiler/generate/t_mstch_objects.h
@@ -790,7 +790,7 @@ class mstch_type : public mstch_base {
   mstch::node stream_has_first_response() {
     return resolved_type_->is_streamresponse() &&
         dynamic_cast<const t_stream_response*>(resolved_type_)
-            ->has_first_response();
+            ->first_response_type() != boost::none;
   }
   mstch::node is_service() { return resolved_type_->is_service(); }
   mstch::node is_base() { return resolved_type_->is_base_type(); }
@@ -1034,9 +1034,9 @@ class mstch_function : public mstch_base {
     return function_->get_sink_final_response_xceptions()->has_fields();
   }
   mstch::node stream_has_first_response() {
-    auto rettype = function_->get_returntype();
-    auto stream = dynamic_cast<const t_stream_response*>(rettype);
-    return stream && stream->has_first_response();
+    const auto& rettype = *function_->return_type();
+    auto stream = dynamic_cast<const t_stream_response*>(&rettype);
+    return stream && stream->first_response_type() != boost::none;
   }
   mstch::node has_args() {
     if (function_->get_paramlist()->has_fields()) {

--- a/thrift/compiler/lib/py3/test/util_test.cc
+++ b/thrift/compiler/lib/py3/test/util_test.cc
@@ -21,6 +21,7 @@
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 
+#include <thrift/compiler/ast/t_base_type.h>
 #include <thrift/compiler/ast/t_field.h>
 
 using namespace apache::thrift::compiler;
@@ -28,11 +29,12 @@ using namespace apache::thrift::compiler;
 class UtilTest : public testing::Test {};
 
 TEST_F(UtilTest, get_py3_name) {
-  EXPECT_EQ("foo", py3::get_py3_name(t_field(nullptr, "foo")));
-  EXPECT_EQ("True_", py3::get_py3_name(t_field(nullptr, "True")));
-  EXPECT_EQ("cpdef_", py3::get_py3_name(t_field(nullptr, "cpdef")));
+  EXPECT_EQ("foo", py3::get_py3_name(t_field(t_base_type::t_i32(), "foo")));
+  EXPECT_EQ("True_", py3::get_py3_name(t_field(t_base_type::t_i32(), "True")));
+  EXPECT_EQ(
+      "cpdef_", py3::get_py3_name(t_field(t_base_type::t_i32(), "cpdef")));
 
-  t_field f(nullptr, "foo");
+  t_field f(t_base_type::t_i32(), "foo");
   f.set_annotation("py3.name", "bar");
   EXPECT_EQ("bar", py3::get_py3_name(f));
 }

--- a/thrift/compiler/parse/parsing_driver.h
+++ b/thrift/compiler/parse/parsing_driver.h
@@ -394,15 +394,19 @@ class parsing_driver {
   std::unique_ptr<t_throws> new_throws(
       std::unique_ptr<t_field_list> exceptions);
 
-  // Creates a reference to a known type.
-  std::unique_ptr<t_type_ref> new_type_ref(
-      const t_type* type, std::unique_ptr<t_annotations> annotations);
+  // Creates a reference to a known type, potentally with additional
+  // annotations.
+  t_type_ref new_type_ref(
+      const t_type& type, std::unique_ptr<t_annotations> annotations);
+  t_type_ref new_type_ref(t_type&& type, std::unique_ptr<t_annotations>) =
+      delete;
+
   // Creates a reference to a newly instantiated templated type.
-  std::unique_ptr<t_type_ref> new_type_ref(
+  t_type_ref new_type_ref(
       std::unique_ptr<t_templated_type> type,
       std::unique_ptr<t_annotations> annotations);
   // Creates a reference to a named type.
-  std::unique_ptr<t_type_ref> new_type_ref(
+  t_type_ref new_type_ref(
       std::string name,
       std::unique_ptr<t_annotations> annotations,
       bool is_const = false);

--- a/thrift/compiler/sema/ast_validator_test.cc
+++ b/thrift/compiler/sema/ast_validator_test.cc
@@ -75,7 +75,7 @@ class StdAstValidatorTest : public ::testing::Test {
   std::unique_ptr<t_const> inst(const t_struct* ttype, int lineno) {
     auto value = std::make_unique<t_const_value>();
     value->set_map();
-    value->set_ttype(std::make_unique<t_type_ref>(ttype));
+    value->set_ttype(t_type_ref::from_ptr(ttype));
     auto result =
         std::make_unique<t_const>(&program_, ttype, "", std::move(value));
     result->set_lineno(lineno);

--- a/thrift/compiler/sema/scope_validator_test.cc
+++ b/thrift/compiler/sema/scope_validator_test.cc
@@ -128,7 +128,7 @@ class ScopeValidatorTest : public ::testing::Test {
   std::unique_ptr<t_const> inst(const t_struct* ttype) {
     auto value = std::make_unique<t_const_value>();
     value->set_map();
-    value->set_ttype(std::make_unique<t_type_ref>(ttype));
+    value->set_ttype(t_type_ref::from_ptr(ttype));
     return std::make_unique<t_const>(&program, ttype, "", std::move(value));
   }
 
@@ -178,11 +178,11 @@ TEST_F(ScopeValidatorTest, Excpetion) {
 }
 
 TEST_F(ScopeValidatorTest, Field) {
-  runTest(t_field{&t_base_type::t_i32(), "my_field"}, "Field");
+  runTest(t_field{t_base_type::t_i32(), "my_field"}, "Field");
 }
 
 TEST_F(ScopeValidatorTest, Typedef) {
-  runTest(t_typedef{&program, "MyTypedef", &t_base_type::t_void()}, "Typedef");
+  runTest(t_typedef{&program, "MyTypedef", t_base_type::t_void()}, "Typedef");
 }
 
 TEST_F(ScopeValidatorTest, Service) {
@@ -196,7 +196,7 @@ TEST_F(ScopeValidatorTest, Interaction) {
 TEST_F(ScopeValidatorTest, Function) {
   runTest(
       t_function{
-          &t_base_type::t_i32(),
+          t_base_type::t_i32(),
           "my_func",
           std::make_unique<t_paramlist>(&program)},
       "Function");
@@ -211,8 +211,7 @@ TEST_F(ScopeValidatorTest, EnumValue) {
 }
 
 TEST_F(ScopeValidatorTest, Const) {
-  runTest(
-      t_const{&program, &t_base_type::t_i32(), "MyConst", nullptr}, "Const");
+  runTest(t_const{&program, t_base_type::t_i32(), "MyConst", nullptr}, "Const");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Making accesses safer and simplifying a bunch of code. In the process:
- Add helper to safely convert from raw 'const t_type*' (only for backwards compat)
- Make t_type_ref only directly constructable from a l-value `const t_type&`
- Hide access to `t_type_ref::set_type` which should only be used to set a resolved type.
- Remove questionable 'consume' helper function.

Reviewed By: yfeldblum

Differential Revision: D29000281

fbshipit-source-id: b614b274889c3182a947323c6265bc04a5054279