### PR TITLE
RU-AXAV: Socket write timeout

### DIFF
--- a/thrift/lib/cpp2/transport/rocket/server/RocketRoutingHandler.cpp
+++ b/thrift/lib/cpp2/transport/rocket/server/RocketRoutingHandler.cpp
@@ -129,6 +129,7 @@ void RocketRoutingHandler::handleConnection(
       std::move(sock),
       std::make_unique<rocket::ThriftRocketServerHandler>(
           worker, *address, sockPtr, setupFrameHandlers_),
+      server->getSocketWriteTimeout(),
       server->getStreamExpireTime(),
       server->getWriteBatchingInterval(),
       server->getWriteBatchingSize(),

--- a/thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.h
+++ b/thrift/lib/cpp2/transport/rocket/server/RocketServerConnection.h
@@ -66,6 +66,7 @@ class RocketServerConnection final
   RocketServerConnection(
       folly::AsyncTransport::UniquePtr socket,
       std::unique_ptr<RocketServerHandler> frameHandler,
+      std::chrono::milliseconds socketWriteTimeout,
       std::chrono::milliseconds streamStarvationTimeout,
       std::chrono::milliseconds writeBatchingInterval,
       size_t writeBatchingSize,

--- a/thrift/lib/cpp2/transport/rocket/test/fuzz/FuzzUtil.h
+++ b/thrift/lib/cpp2/transport/rocket/test/fuzz/FuzzUtil.h
@@ -127,6 +127,7 @@ void testServerOneInput(const uint8_t* Data, size_t Size) {
       std::move(sock),
       std::make_unique<apache::thrift::rocket::ThriftRocketServerHandler>(
           worker, address, sockPtr, v),
+      std::chrono::milliseconds::zero(), // (socketWriteTimeout)
       std::chrono::seconds(60), // (streamStarvationTimeout)
       std::chrono::milliseconds::zero(), // (writeBatchingInterval)
       0, // (writeBatchingSize)

--- a/thrift/lib/cpp2/transport/rocket/test/network/ClientServerTestUtil.cpp
+++ b/thrift/lib/cpp2/transport/rocket/test/network/ClientServerTestUtil.cpp
@@ -321,6 +321,7 @@ class RocketTestServerAcceptor final : public wangle::Acceptor {
     auto* connection = new RocketServerConnection(
         std::move(socket),
         frameHandlerFactory_(),
+        std::chrono::milliseconds::zero(), // (socketWriteTimeout)
         std::chrono::seconds(60), // (streamStarvationTimeout)
         std::chrono::milliseconds::zero(), // (writeBatchingInterval)
         0, // (writeBatchingSize)


### PR DESCRIPTION
Summary:
`setSocketWriteTimeout()` defines how long a socket with outbound data will
tolerate read inactivity from a client. Clients must read data from their end
of the connection before this period expires or the server will drop the
connection. The amount of data read by the client is irrelevant. Zero disables
the timeout.

Reviewed By: praihan

Differential Revision: D29468596

fbshipit-source-id: bee339971cf9068fe51d2cdb134e078f4aaf509e