### PR TITLE
RU-AXAV: Pluggable function for dumping snapshot on worker join timeout

### DIFF
--- a/thrift/lib/cpp2/server/Cpp2Worker.cpp
+++ b/thrift/lib/cpp2/server/Cpp2Worker.cpp
@@ -347,7 +347,7 @@ void Cpp2Worker::requestStop() {
   });
 }
 
-bool Cpp2Worker::waitForStop(std::chrono::system_clock::time_point deadline) {
+bool Cpp2Worker::waitForStop(std::chrono::steady_clock::time_point deadline) {
   if (!stopBaton_.try_wait_until(deadline)) {
     LOG(ERROR) << "Failed to join outstanding requests.";
     return false;

--- a/thrift/lib/cpp2/server/Cpp2Worker.h
+++ b/thrift/lib/cpp2/server/Cpp2Worker.h
@@ -301,7 +301,7 @@ class Cpp2Worker : public IOWorkerContext,
   void requestStop();
 
   // returns false if timed out due to deadline
-  bool waitForStop(std::chrono::system_clock::time_point deadline);
+  bool waitForStop(std::chrono::steady_clock::time_point deadline);
 
   virtual wangle::AcceptorHandshakeHelper::UniquePtr createSSLHelper(
       const std::vector<uint8_t>& bytes,

--- a/thrift/lib/cpp2/server/ThriftServer.h
+++ b/thrift/lib/cpp2/server/ThriftServer.h
@@ -871,6 +871,20 @@ class ThriftServer : public apache::thrift::BaseThriftServer,
   }
   folly::SemiFuture<ServerSnapshot> getServerSnapshot(
       const SnapshotOptions& options);
+
+  /**
+   * If shutdown does not complete within the configured worker join timeout,
+   * then we schedule a task to dump the server's state to disk for
+   * investigation.
+   *
+   * The implementor of the dumping logic should provide the the task as well
+   * as an appropriate timeout -- we do not want to indefinitely block shutdown
+   * in case the task deadlocks.
+   */
+  struct DumpSnapshotOnLongShutdownResult {
+    folly::SemiFuture<folly::Unit> task;
+    std::chrono::milliseconds timeout;
+  };
 };
 
 template <typename AcceptorClass, typename SharedSSLContextManagerClass>


### PR DESCRIPTION
Summary: If the workers did not join within the join timeout, they might be deadlocked. Let's dump a snapshot to see what they are up to before they quit.

Reviewed By: roddym

Differential Revision: D29503465

fbshipit-source-id: f2cda4e76462a5efad4a522205556a688b0a6739