### PR TITLE
RU-AXAV: thrift: varint: BMI2: fix for Windows/32 bit: use __builtin_clzll(lon…

### DIFF
--- a/thrift/lib/cpp/util/VarintUtils-inl.h
+++ b/thrift/lib/cpp/util/VarintUtils-inl.h
@@ -213,10 +213,10 @@ uint8_t writeVarintBMI2(Cursor& c, T valueS) {
     return v;
   }();
 
-  auto clzl = __builtin_clzl(static_cast<uint64_t>(value));
+  auto clzll = __builtin_clzll(static_cast<uint64_t>(value));
   // Only the first 56 bits of @value will be deposited in @v.
-  uint64_t v = _pdep_u64(value, ~kMask) | (kMask >> kShift[clzl]);
-  uint8_t size = kSize[clzl];
+  uint64_t v = _pdep_u64(value, ~kMask) | (kMask >> kShift[clzll]);
+  uint8_t size = kSize[clzll];
 
   if (sizeof(T) < sizeof(uint64_t)) {
     c.template write<uint64_t>(v, size);


### PR DESCRIPTION
…g long)

Summary:
`__builtin_clzl(long)` on 32-bit and x64 Windows is 32-bits, while on x64 Linux it's 64-bits.

Switch to `__builtin_clzll(long long)` which is 64 bit on both 32 & 64 bit platforms on both Linux and Windows.

Reviewed By: vitaut

Differential Revision: D29890599

fbshipit-source-id: bd3e6ce931177e9c1d681eaf7b7e3d5c7c90e0d0